### PR TITLE
Update OneClick link

### DIFF
--- a/scoresaber.user.js
+++ b/scoresaber.user.js
@@ -440,7 +440,7 @@ async function oneclick_install(full_id) {
         if (resp === 'install') window.open('https://github.com/beat-saber-modding-group/BeatSaberModInstaller/releases');
     }
 
-    window.location.assign(`beatdrop://download/${full_id}`);
+    window.location.assign(`beatsaver://${full_id}`);
 }
 
 /**


### PR DESCRIPTION
Haven't tested this with BeatDrop, but it's the link I see on BeatSaver for their OneClick install and it uses my selected mod manager (ModAssistant)