### PR TITLE
Workaround for issue with users not updating properly if they have too many pages of scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The generated output file is always `scoresaber.user.js`.
 
 # Changelog
 
+1.8.1b
+ - Added workaround for issue with some users not being successfully added to dropdown list
+
 1.8.1
  - Added !bsr button
 

--- a/scoresaber.user.js
+++ b/scoresaber.user.js
@@ -895,6 +895,10 @@
 	        if ((!force && has_old_entry) || recent_songs.meta.was_last_page) {
 	            break;
 	        }
+		if (page % 40 === 0) {
+                    SseEvent.StatusInfo.invoke({ text: `too many pages, sleeping for 25 seconds...` });
+                    await sleep(25000);
+                }
 	    }
 	    user.name = user_name !== null && user_name !== void 0 ? user_name : user.name;
 	    if (updated) {


### PR DESCRIPTION
I don't really know what I'm doing, so I don't know if this is a good way to do it or not (I'm guessing probably not), but it works for me, and I haven't seen any issues with it. I was able to successfully add someone with over 300 pages of scores to my drop-down comparison with this, whereas before it would always stall at around page 80.

All this does is waits for 25 seconds every 40 pages it updates, this seems to allow scoresaber to not stall out the requests.