### PR TITLE
Fix missing Chart library

### DIFF
--- a/scoresaber.user.js
+++ b/scoresaber.user.js
@@ -10,6 +10,7 @@
 // @updateURL    https://github.com/Splamy/ScoreSaberEnhanced/raw/master/scoresaber.user.js
 // @downloadURL  https://github.com/Splamy/ScoreSaberEnhanced/raw/master/scoresaber.user.js
 // @require      https://cdn.jsdelivr.net/npm/moment@2.24.0/moment.js
+// @require      https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js
 // @run-at       document-start
 // for Tampermonkey
 // @grant        GM_xmlhttpRequest

--- a/scoresaber.user.js
+++ b/scoresaber.user.js
@@ -10,7 +10,7 @@
 // @updateURL    https://github.com/Splamy/ScoreSaberEnhanced/raw/master/scoresaber.user.js
 // @downloadURL  https://github.com/Splamy/ScoreSaberEnhanced/raw/master/scoresaber.user.js
 // @require      https://cdn.jsdelivr.net/npm/moment@2.24.0/moment.js
-// @require      https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js
+// @require      https://scoresaber.com/imports/js/chart.js
 // @run-at       document-start
 // for Tampermonkey
 // @grant        GM_xmlhttpRequest

--- a/src/header.user.js
+++ b/src/header.user.js
@@ -8,7 +8,7 @@ include$GULP_METADATA
 // @updateURL    https://github.com/Splamy/ScoreSaberEnhanced/raw/master/scoresaber.user.js
 // @downloadURL  https://github.com/Splamy/ScoreSaberEnhanced/raw/master/scoresaber.user.js
 // @require      https://cdn.jsdelivr.net/npm/moment@2.24.0/moment.js
-// @require      https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js
+// @require      https://scoresaber.com/imports/js/chart.js
 // @run-at       document-start
 // for Tampermonkey
 // @grant        GM_xmlhttpRequest

--- a/src/header.user.js
+++ b/src/header.user.js
@@ -8,6 +8,7 @@ include$GULP_METADATA
 // @updateURL    https://github.com/Splamy/ScoreSaberEnhanced/raw/master/scoresaber.user.js
 // @downloadURL  https://github.com/Splamy/ScoreSaberEnhanced/raw/master/scoresaber.user.js
 // @require      https://cdn.jsdelivr.net/npm/moment@2.24.0/moment.js
+// @require      https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js
 // @run-at       document-start
 // for Tampermonkey
 // @grant        GM_xmlhttpRequest


### PR DESCRIPTION
ScoreSaberEnhanced currently breaks when pressing "Show pp Graph" on my Firefox 79.0b9 and Greasemonkey 4.9, this PR fixes the issue by including the Chart.js library.