### PR TITLE
fix: handle 404 in score pagination (fixes #21)

### DIFF
--- a/scoresaber.user.js
+++ b/scoresaber.user.js
@@ -693,6 +693,12 @@
     }
     async function get_user_recent_songs_new_api_wrap(user_id, page) {
         const recent_songs = await get_user_recent_songs(user_id, page);
+        if (!recent_songs) {
+            return {
+                meta: { was_last_page: true },
+                songs: []
+            };
+        }
         return {
             meta: {
                 was_last_page: recent_songs.scores.length < 8
@@ -708,6 +714,9 @@
     }
     async function get_user_recent_songs(user_id, page) {
         const req = await auto_fetch_retry(`${SCORESABER_LINK}/player/${user_id}/scores/recent/${page}`);
+        if (req.status === 404) {
+            return null;
+        }
         const data = await req.json();
         return sanitize_song_ids(data);
     }


### PR DESCRIPTION
This is a simple patch for #21. If a 404 is encountered during score pagination, it will return `null` during the API call, and an empty score list with `was_last_page: true` for the wrapped version of the call.